### PR TITLE
Add fix for slice error

### DIFF
--- a/internal/anna/anna.go
+++ b/internal/anna/anna.go
@@ -25,7 +25,7 @@ const (
 
 func extractMetaInformation(meta string) (language, format, size string) {
 	parts := strings.Split(meta, ", ")
-	if len(parts) < 5 {
+	if len(parts) < 4 {
 		return "", "", ""
 	}
 
@@ -71,9 +71,14 @@ func FindBook(query string) ([]*Book, error) {
 		link := e.Attr("href")
 		hash := strings.TrimPrefix(link, "/md5/")
 
+		trimmedFormat := strings.TrimSpace(format)
+		if len(trimmedFormat) > 0 {
+			trimmedFormat = trimmedFormat[1:]
+		}
+
 		book := &Book{
 			Language:  strings.TrimSpace(language),
-			Format:    strings.TrimSpace(format)[1:],
+			Format:    trimmedFormat,
 			Size:      strings.TrimSpace(size),
 			Title:     strings.TrimSpace(title),
 			Publisher: strings.TrimSpace(publisher),


### PR DESCRIPTION
Thanks so much for creating this fantastic tool.

I got a panic with the following error:

```
2025-07-16T21:08:30.899Z [anna-mcp] [info] Message from client: {"method":"tools/call","params":{"name":"search","arguments":{"term":"Lord Kelvin Russell"}},"jsonrpc":"2.0","id":27} { metadata: undefined }
{"level":"info","ts":1752700110.90017,"caller":"modes/mcpserver.go:16","msg":"Search command called","searchTerm":"Lord Kelvin Russell"}
{"level":"info","ts":1752700110.900268,"caller":"anna/anna.go:55","msg":"Visiting URL","url":"https://annas-archive.org/search?q=Lord+Kelvin+Russell"}
panic: runtime error: slice bounds out of range [1:0]

goroutine 7 [running]:
github.com/iosifache/annas-mcp/internal/anna.FindBook({0x140004c6030, 0x13})
	annas-mcp/internal/anna/anna.go:76 +0x64c
github.com/iosifache/annas-mcp/internal/modes.SearchTool({0x140004be0a0?, 0x1e?}, 0x20?, 0x140004b86f0)
	annas-mcp/internal/modes/mcpserver.go:20 +0xf0
github.com/modelcontextprotocol/go-sdk/mcp.newServerToolErr[...].func1(0x140000c2f50, 0x140004b8630)
	go/pkg/mod/github.com/modelcontextprotocol/go-sdk@v0.1.0/mcp/tool.go:94 +0x120
github.com/modelcontextprotocol/go-sdk/mcp.(*Server).callTool(0x16?, {0x100daf4f8, 0x140004b8600}, 0x140000c2f50, 0x140004b8630)
	go/pkg/mod/github.com/modelcontextprotocol/go-sdk@v0.1.0/mcp/server.go:311 +0x1c0
github.com/modelcontextprotocol/go-sdk/mcp.init.serverMethod[...].func61(0x1400009b0c0?, 0x1400041ebb0?)
	go/pkg/mod/github.com/modelcontextprotocol/go-sdk@v0.1.0/mcp/shared.go:191 +0x44
github.com/modelcontextprotocol/go-sdk/mcp.init.newMethodInfo[...].func63(0x1400041ebb0?, {0xa?, 0x140000b9d68?}, {0x100da9558?, 0x140004b8630?})
	go/pkg/mod/github.com/modelcontextprotocol/go-sdk@v0.1.0/mcp/shared.go:176 +0x50
github.com/modelcontextprotocol/go-sdk/mcp.defaultReceivingMethodHandler[...]({0x100daf4f8, 0x140004b8600}, 0x140000c2f50, {0x1400041ebb0, 0xa}, {0x100da9558, 0x140004b8630})
	go/pkg/mod/github.com/modelcontextprotocol/go-sdk@v0.1.0/mcp/shared.go:111 +0xa0
github.com/modelcontextprotocol/go-sdk/mcp.handleReceive[...]({0x100daf4f8, 0x140004b8600}, 0x140000c2f50, 0x140002fb280)
	go/pkg/mod/github.com/modelcontextprotocol/go-sdk@v0.1.0/mcp/shared.go:126 +0x160
github.com/modelcontextprotocol/go-sdk/mcp.(*ServerSession).handle(0x140000c2f50, {0x100daf530, 0x1400043c370}, 0x140002fb280)
	go/pkg/mod/github.com/modelcontextprotocol/go-sdk@v0.1.0/mcp/server.go:648 +0x1c8
github.com/modelcontextprotocol/go-sdk/internal/jsonrpc2.HandlerFunc.Handle(0x140002f0dd0?, {0x100daf530?, 0x1400043c370?}, 0x2226222c223b7467?)
	go/pkg/mod/github.com/modelcontextprotocol/go-sdk@v0.1.0/internal/jsonrpc2/jsonrpc2.go:91 +0x38
github.com/modelcontextprotocol/go-sdk/internal/jsonrpc2.(*Connection).handleAsync(0x140002f0dd0)
	go/pkg/mod/github.com/modelcontextprotocol/go-sdk@v0.1.0/internal/jsonrpc2/conn.go:661 +0xe0
created by github.com/modelcontextprotocol/go-sdk/internal/jsonrpc2.(*Connection).acceptRequest.func2 in goroutine 21
	go/pkg/mod/github.com/modelcontextprotocol/go-sdk@v0.1.0/internal/jsonrpc2/conn.go:624 +0x14c
```

After a little bit of debugging, it seems that the panic `runtime error: slice bounds out of range [1:0]` on line 76 of `annas-mcp/internal/anna/anna.go` is caused by attempting to slice an empty string. This happens in the line `Format: strings.TrimSpace(format)[1:]` when `format` is an empty string. This is because the `extractMetaInformation` function can return an empty `format` if the metadata from the website is not in the expected format.

I made two changes to fix this issue and improve robustness:

1.  In `extractMetaInformation`, I adjusted the length check of the `parts` slice to correctly handle the metadata. The original check for `len(parts) < 5` is too strict and should be `len(parts) < 4` since the code accesses up to `parts[3]`.
2.  In `FindBook`, I added a check to ensure that `format` is not an empty string before attempting to slice it. This will prevent the panic from occurring, even if `extractMetaInformation` returns an empty format string for any reason.
