### PR TITLE
Fix search scraping and fast download indices

### DIFF
--- a/internal/anna/anna.go
+++ b/internal/anna/anna.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/url"
 
+	"regexp"
 	"strings"
 
 	"encoding/json"
@@ -13,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/PuerkitoBio/goquery"
 	colly "github.com/gocolly/colly/v2"
 	"github.com/iosifache/annas-mcp/internal/env"
 	"github.com/iosifache/annas-mcp/internal/logger"
@@ -20,7 +22,7 @@ import (
 )
 
 const (
-	AnnasSearchEndpointFormat   = "https://{}/search?q=%s"
+	AnnasSearchEndpointFormat   = "https://%s/search?q=%s"
 	AnnasDownloadEndpointFormat = "https://{}/dyn/api/fast_download.json?md5=%s&key=%s"
 )
 
@@ -65,6 +67,16 @@ func extractMetaInformation(meta string) (language, format, size string) {
 	return language, format, size
 }
 
+func extractFormatFromFilename(filename string) string {
+	re := regexp.MustCompile(`(?i)\.(epub|pdf|mobi|azw3|azw|djvu|cbz|cbr|rtf|txt|docx?|fb2|lit)\b`)
+	match := re.FindStringSubmatch(filename)
+	if len(match) < 2 {
+		return ""
+	}
+
+	return strings.ToUpper(match[1])
+}
+
 func FindBook(query string) ([]*Book, error) {
 	l := logger.GetLogger()
 
@@ -74,45 +86,83 @@ func FindBook(query string) ([]*Book, error) {
 
 	bookList := make([]*colly.HTMLElement, 0)
 
-	c.OnHTML("a[href^='/md5/']", func(e *colly.HTMLElement) {
-		// Only process the first link (the cover image link), not the duplicate title link
-		if e.Attr("class") == "custom-a block mr-2 sm:mr-4 hover:opacity-80" {
-			bookList = append(bookList, e)
-		}
+	c.OnHTML("div.js-aarecord-list-outer > div", func(e *colly.HTMLElement) {
+		// Collect result items to avoid processing duplicate md5 links per result.
+		bookList = append(bookList, e)
 	})
 
 	c.OnRequest(func(r *colly.Request) {
 		l.Info("Visiting URL", zap.String("url", r.URL.String()))
 	})
 
-	env, err := env.GetEnv()
+	c.OnError(func(r *colly.Response, err error) {
+		status := 0
+		if r != nil {
+			status = r.StatusCode
+		}
+		l.Warn("Search request failed",
+			zap.Int("status", status),
+			zap.Error(err),
+		)
+	})
+
+	envVars, err := env.GetEnv()
 	if err != nil {
 		return nil, err
 	}
 
-	annasSearchEndpoint := fmt.Sprintf(AnnasSearchEndpointFormat, env.AnnasBaseURL)
+	annasSearchEndpoint := fmt.Sprintf(AnnasSearchEndpointFormat, envVars.AnnasBaseURL)
 	fullURL := fmt.Sprintf(annasSearchEndpoint, url.QueryEscape(query))
-	c.Visit(fullURL)
+	if err := c.Visit(fullURL); err != nil {
+		l.Warn("Search visit failed", zap.Error(err))
+		return nil, err
+	}
 	c.Wait()
 
 	bookListParsed := make([]*Book, 0)
 	for _, e := range bookList {
-		bookInfoDiv := e.DOM.Parent().Find("div.max-w-full")
+		titleCandidates := e.DOM.Find("a[href^='/md5/']")
+		if titleCandidates.Length() == 0 {
+			continue
+		}
+		titleLink := titleCandidates.FilterFunction(func(_ int, s *goquery.Selection) bool {
+			return strings.TrimSpace(s.Text()) != ""
+		}).First()
+		if titleLink.Length() == 0 {
+			titleLink = titleCandidates.First()
+		}
+		title := strings.TrimSpace(titleLink.Text())
 
-		title := bookInfoDiv.Find("a[href^='/md5/']").Text()
-
-		authorsRaw := bookInfoDiv.Find("a[href^='/search'] span.icon-\\[mdi--user-edit\\]").Parent().Text()
+		authorsSelection := e.DOM.Find("a[href^='/search?q='] span.icon-\\[mdi--user-edit\\]").First()
+		if authorsSelection.Length() == 0 {
+			authorsSelection = e.DOM.Find("span.icon-\\[mdi--user-edit\\]").First()
+		}
+		authorsRaw := authorsSelection.Parent().Text()
 		authors := strings.TrimSpace(authorsRaw)
 
-		publisherRaw := bookInfoDiv.Find("a[href^='/search'] span.icon-\\[mdi--company\\]").Parent().Text()
+		publisherSelection := e.DOM.Find("a[href^='/search?q='] span.icon-\\[mdi--company\\]").First()
+		if publisherSelection.Length() == 0 {
+			publisherSelection = e.DOM.Find("span.icon-\\[mdi--company\\]").First()
+		}
+		publisherRaw := publisherSelection.Parent().Text()
 		publisher := strings.TrimSpace(publisherRaw)
 
-		meta := bookInfoDiv.Find("div.text-gray-800").Text()
+		meta := e.DOM.Find("div.text-gray-800").First().Text()
 
 		language, format, size := extractMetaInformation(meta)
+		if format == "" {
+			filenameLine := strings.TrimSpace(e.DOM.Find("div.font-mono").First().Text())
+			format = extractFormatFromFilename(filenameLine)
+		}
 
-		link := e.Attr("href")
+		link, ok := titleLink.Attr("href")
+		if !ok || link == "" {
+			continue
+		}
 		hash := strings.TrimPrefix(link, "/md5/")
+		if strings.Contains(hash, "/") {
+			hash = strings.SplitN(hash, "/", 2)[0]
+		}
 
 		book := &Book{
 			Language:  language,

--- a/internal/anna/anna.go
+++ b/internal/anna/anna.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 
 	"regexp"
+	"strconv"
 	"strings"
 
 	"encoding/json"
@@ -181,13 +182,13 @@ func FindBook(query string) ([]*Book, error) {
 	return bookListParsed, nil
 }
 
-func (b *Book) Download(secretKey, folderPath string) error {
+func (b *Book) Download(secretKey, folderPath string, pathIndex, domainIndex int) error {
 	apiURL := fmt.Sprintf(AnnasDownloadEndpointFormat, env.DefaultAnnasBaseURL)
 	params := url.Values{}
 	params.Set("md5", b.Hash)
 	params.Set("key", secretKey)
-	params.Set("path_index", "0")
-	params.Set("domain_index", "0")
+	params.Set("path_index", strconv.Itoa(pathIndex))
+	params.Set("domain_index", strconv.Itoa(domainIndex))
 	apiURL = apiURL + "?" + params.Encode()
 
 	resp, err := http.Get(apiURL)

--- a/internal/anna/anna.go
+++ b/internal/anna/anna.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	AnnasSearchEndpointFormat   = "https://%s/search?q=%s"
-	AnnasDownloadEndpointFormat = "https://{}/dyn/api/fast_download.json?md5=%s&key=%s"
+	AnnasDownloadEndpointFormat = "https://%s/dyn/api/fast_download.json"
 )
 
 func extractMetaInformation(meta string) (language, format, size string) {
@@ -182,13 +182,13 @@ func FindBook(query string) ([]*Book, error) {
 }
 
 func (b *Book) Download(secretKey, folderPath string) error {
-	env, err := env.GetEnv()
-	if err != nil {
-		return err
-	}
-
-	annasDownloadEndpoint := fmt.Sprintf(AnnasDownloadEndpointFormat, env.AnnasBaseURL)
-	apiURL := fmt.Sprintf(annasDownloadEndpoint, b.Hash, secretKey)
+	apiURL := fmt.Sprintf(AnnasDownloadEndpointFormat, env.DefaultAnnasBaseURL)
+	params := url.Values{}
+	params.Set("md5", b.Hash)
+	params.Set("key", secretKey)
+	params.Set("path_index", "0")
+	params.Set("domain_index", "0")
+	apiURL = apiURL + "?" + params.Encode()
 
 	resp, err := http.Get(apiURL)
 	if err != nil {

--- a/internal/modes/cli.go
+++ b/internal/modes/cli.go
@@ -86,6 +86,15 @@ func StartCLI() {
 			bookHash := args[0]
 			filename := args[1]
 
+			pathIndex, err := cmd.Flags().GetInt("path-index")
+			if err != nil {
+				return fmt.Errorf("failed to read path-index flag: %w", err)
+			}
+			domainIndex, err := cmd.Flags().GetInt("domain-index")
+			if err != nil {
+				return fmt.Errorf("failed to read domain-index flag: %w", err)
+			}
+
 			ext := filepath.Ext(filename)
 			if ext == "" {
 				return fmt.Errorf("filename must include an extension (e.g., .pdf, .epub)")
@@ -112,7 +121,7 @@ func StartCLI() {
 				Format: format,
 			}
 
-			err = book.Download(env.SecretKey, env.DownloadPath)
+			err = book.Download(env.SecretKey, env.DownloadPath, pathIndex, domainIndex)
 			if err != nil {
 				l.Error("Download command failed",
 					zap.String("bookHash", bookHash),
@@ -134,6 +143,8 @@ func StartCLI() {
 			return nil
 		},
 	}
+	downloadCmd.Flags().Int("path-index", 0, "Collection path index for fast downloads")
+	downloadCmd.Flags().Int("domain-index", 0, "Fast download server index")
 
 	mcpCmd := &cobra.Command{
 		Use:   "mcp",

--- a/internal/modes/mcpserver.go
+++ b/internal/modes/mcpserver.go
@@ -68,7 +68,7 @@ func DownloadTool(ctx context.Context, cc *mcp.ServerSession, params *mcp.CallTo
 		Format: format,
 	}
 
-	err = book.Download(secretKey, downloadPath)
+	err = book.Download(secretKey, downloadPath, 0, 0)
 	if err != nil {
 		l.Error("Download command failed",
 			zap.String("bookHash", params.Arguments.BookHash),


### PR DESCRIPTION
## Summary
- update search scraping to use resilient selectors and filename-based format fallback
- prefer text-bearing md5 links per result to avoid cover/title duplication
- include default path/domain indices in fast_download API calls
- add download flags for path/domain indices so callers can override defaults

## Notes
Hi, I came across this MCP, but noticed it was broken, so I thought I'd have a crack at fixing the CSS selectors used

Full Disclosure: I'm not a Golang developer, so I used Opencode with GPT5.2 Codex for this PR

resolves #6