### PR TITLE
fix: Update search URL format and domain for working scraping

### DIFF
--- a/internal/anna/anna.go
+++ b/internal/anna/anna.go
@@ -20,8 +20,9 @@ import (
 )
 
 const (
-	AnnasSearchEndpointFormat   = "https://{}/search?q=%s"
-	AnnasDownloadEndpointFormat = "https://{}/dyn/api/fast_download.json?md5=%s&key=%s"
+	// content=book_any forces server-side rendering of results (required for scraping)
+	AnnasSearchEndpointFormat   = "https://%s/search?q=%s&content=book_any"
+	AnnasDownloadEndpointFormat = "https://%s/dyn/api/fast_download.json?md5=%s&key=%s"
 )
 
 func extractMetaInformation(meta string) (language, format, size string) {
@@ -70,6 +71,7 @@ func FindBook(query string) ([]*Book, error) {
 
 	c := colly.NewCollector(
 		colly.Async(true),
+		colly.UserAgent("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"),
 	)
 
 	bookList := make([]*colly.HTMLElement, 0)

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -8,7 +8,8 @@ import (
 	"go.uber.org/zap"
 )
 
-const DefaultAnnasBaseURL = "annas-archive.li"
+// annas-archive.org was suspended in Jan 2026; .pm is currently working
+const DefaultAnnasBaseURL = "annas-archive.pm"
 
 type Env struct {
 	SecretKey    string `json:"secret"`


### PR DESCRIPTION
## Summary

Three issues were preventing search from working:

1. **URL format bug**: Used `{}` placeholder instead of `%s` for Sprintf - so the domain was never substituted
2. **Dead domain**: Default domain `annas-archive.li` is no longer accessible (`.org` was suspended in Jan 2026)
3. **JS-rendered results**: Without `content=book_any` parameter, search returns JS-only content that colly can't scrape
4. **User-Agent blocking**: Default colly user-agent is blocked by DDoS-Guard

## Changes

- Fix URL format strings to use proper `%s` placeholders
- Update default domain to `annas-archive.pm` (working as of Feb 2026)  
- Add `content=book_any` to force server-side rendering of search results
- Set browser-like User-Agent to avoid DDoS-Guard blocking

## Test Results

Before:
```
$ ./annas-mcp search "python"
No books found.
```

After:
```
$ ./annas-mcp search "python"
Book 1:
Title: An empirical comparison of C,C++,Java,Perl,Python,Rexx,and Tcl...
Authors: Prechelt L.
...
(50 results)
```

Fixes #6

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)