### PR TITLE
Auto-select Anna mirrors from open-slum at startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,12 @@ The environment should contain two variables:
 
 Optionally, you can set:
 
-- `ANNAS_BASE_URL`: The base URL of the Anna's Archive mirror to use (defaults to `annas-archive.li`).
+- `ANNAS_BASE_URL`: A fallback Anna mirror used if automatic mirror discovery fails.
+- `ANNAS_FIXED_BASE_URL`: A fixed Anna mirror that disables automatic discovery entirely.
 
 These variables can also be stored in an `.env` file in the folder containing the binary.
+
+By default, the tool now attempts to discover the best available Anna mirror at process startup by reading [The Shadow Library Uptime Monitor](https://open-slum.org/) and then locally probing the discovered candidates. If discovery or probing fails, the tool falls back to `ANNAS_BASE_URL`, then to the built-in default mirror. If you need to pin a specific mirror, use `ANNAS_FIXED_BASE_URL`.
 
 ## Setup
 
@@ -49,7 +52,8 @@ If you plan to use the tool for its MCP server functionality, you need to integr
     "args": ["mcp"],
     "env": {
         "ANNAS_SECRET_KEY": "feedfacecafebeef",
-        "ANNAS_DOWNLOAD_PATH": "/Users/iosifache/Downloads"
+        "ANNAS_DOWNLOAD_PATH": "/Users/iosifache/Downloads",
+        "ANNAS_BASE_URL": "annas-archive.li"
     }
 }
 ```
@@ -66,15 +70,6 @@ If you plan to use the tool for its MCP server functionality, you need to integr
 
 ## Anna's Archive Mirrors
 
-Anna's Archive has multiple mirrors, which may be innactive at times due to various reasons. Below is a list of known mirrors and their status as of January 2025:
+Anna's Archive has multiple mirrors, and their availability can change over time. This project now checks [The Shadow Library Uptime Monitor](https://open-slum.org) automatically at startup, dynamically discovers Anna mirror candidates from the public status page, ranks them by recent health and latency, and confirms reachability locally before using one.
 
-| Mirror                                           | Type     | Status    |
-| ------------------------------------------------ | -------- | --------- |
-| [`annas-archive.li`](https://annas-archive.li)   | Official | Active    |
-| [`annas-archive.pm`](https://annas-archive.pm)   | Official | Active    |
-| [`annas-archive.in`](https://annas-archive.in)   | Official | Active    |
-| [`annas-archive.org`](https://annas-archive.org) | Official | Innactive |
-
-Alternatively, use [The Shadow Library Uptime Monitor](https://open-slum.org) to find statuses or alternative mirrors.
-
-This project defaults to `annas-archive.li`. If that mirror is not working for you, please set the `ANNAS_BASE_URL` environment variable to one of the other mirrors.
+If you want the tool to choose a mirror automatically, you do not need to configure anything beyond the required environment variables. If you want a safety net for environments where automatic discovery may fail, set `ANNAS_BASE_URL` to your preferred fallback mirror. If you want to fully disable automatic selection and always use one mirror, set `ANNAS_FIXED_BASE_URL`.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Anna's Archive MCP Server (and CLI Tool)
 
-[An MCP server](https://modelcontextprotocol.io/introduction) and CLI tool for searching and downloading documents from [Anna's Archive](https://annas-archive.li)
+[An MCP server](https://modelcontextprotocol.io/introduction) and CLI tool for searching and downloading documents from [Anna's Archive](https://annas-archive.li), with optional automatic selection of a mirror reported as healthy by the public [open-slum monitor](https://open-slum.org/).
 
 > [!NOTE]
 > Notwithstanding prevailing public sentiment regarding Anna's Archive, the platform serves as a comprehensive repository for automated retrieval of documents released under permissive licensing frameworks (including Creative Commons publications and public domain materials). This software does not endorse unauthorized acquisition of copyrighted content and should be regarded solely as a utility. Users are urged to respect the intellectual property rights of authors and acknowledge the considerable effort invested in document creation.
@@ -32,9 +32,12 @@ If using the project as an MCP server, you also need an MCP client, such as [Cla
 
 Optionally, you can set:
 
-- `ANNAS_BASE_URL`: The base URL of the Anna's Archive mirror to use (defaults to `annas-archive.li`).
+- `ANNAS_BASE_URL`: The Anna mirror to use (defaults to `annas-archive.li`). When automatic mirror discovery is enabled, this becomes the fallback mirror.
+- `ANNAS_AUTO_BASE_URL`: Set to `true` to discover the best available Anna mirror automatically from [The Shadow Library Uptime Monitor](https://open-slum.org/).
 
 These variables can also be stored in an `.env` file in the folder containing the binary.
+
+By default, the tool uses `ANNAS_BASE_URL`, or the built-in default mirror when `ANNAS_BASE_URL` is not set. Automatic discovery is opt-in: when `ANNAS_AUTO_BASE_URL=true`, the tool reads the public status page, ranks discovered Anna mirror candidates by recent health and latency, probes them locally, and uses the best reachable mirror. If discovery or probing fails, the tool falls back to `ANNAS_BASE_URL`, then to the built-in default mirror.
 
 HTTP requests default to a 1 hour timeout. For CLI usage, override this with `--timeout`, for example:
 
@@ -56,7 +59,8 @@ If you plan to use the tool for its MCP server functionality, you need to integr
     "args": ["mcp"],
     "env": {
         "ANNAS_SECRET_KEY": "feedfacecafebeef",
-        "ANNAS_DOWNLOAD_PATH": "/Users/iosifache/Downloads"
+        "ANNAS_DOWNLOAD_PATH": "/Users/iosifache/Downloads",
+        "ANNAS_BASE_URL": "annas-archive.li"
     }
 }
 ```
@@ -73,15 +77,6 @@ If you plan to use the tool for its MCP server functionality, you need to integr
 
 ## Anna's Archive Mirrors
 
-Anna's Archive has multiple mirrors, which may be innactive at times due to various reasons. Below is a list of known mirrors and their status as of January 2025:
+Anna's Archive has multiple mirrors, and their availability can change over time. By default, this project uses `ANNAS_BASE_URL`, or `annas-archive.li` when `ANNAS_BASE_URL` is not set.
 
-| Mirror                                           | Type     | Status    |
-| ------------------------------------------------ | -------- | --------- |
-| [`annas-archive.li`](https://annas-archive.li)   | Official | Active    |
-| [`annas-archive.pm`](https://annas-archive.pm)   | Official | Active    |
-| [`annas-archive.in`](https://annas-archive.in)   | Official | Active    |
-| [`annas-archive.org`](https://annas-archive.org) | Official | Innactive |
-
-Alternatively, use [The Shadow Library Uptime Monitor](https://open-slum.org) to find statuses or alternative mirrors.
-
-This project defaults to `annas-archive.li`. If that mirror is not working for you, please set the `ANNAS_BASE_URL` environment variable to one of the other mirrors.
+If you want the tool to choose a mirror automatically, set `ANNAS_AUTO_BASE_URL=true`. In this mode, the tool checks [The Shadow Library Uptime Monitor](https://open-slum.org), dynamically discovers Anna mirror candidates from the public status page, ranks them by recent health and latency, and confirms reachability locally before using one. Set `ANNAS_BASE_URL` as a fallback for environments where automatic discovery may fail.

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -1,12 +1,16 @@
 package env
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync"
 
 	"github.com/iosifache/annas-mcp/internal/logger"
+	"github.com/iosifache/annas-mcp/internal/mirror"
 	"go.uber.org/zap"
 )
 
@@ -18,12 +22,20 @@ type Env struct {
 	AnnasBaseURL string `json:"annas_base_url"`
 }
 
+var (
+	resolvedEnvOnce        sync.Once
+	resolvedAnnasBaseURL   string
+	resolveAnnasBaseURLErr error
+	resolveAnnasBaseURL    = defaultResolveAnnasBaseURL
+)
+
 func GetEnv() (*Env, error) {
 	l := logger.GetLogger()
 
 	secretKey := os.Getenv("ANNAS_SECRET_KEY")
 	downloadPath := os.Getenv("ANNAS_DOWNLOAD_PATH")
-	annasBaseURL := os.Getenv("ANNAS_BASE_URL")
+	fixedBaseURL := normalizeBaseURL(os.Getenv("ANNAS_FIXED_BASE_URL"))
+	fallbackBaseURL := normalizeBaseURL(os.Getenv("ANNAS_BASE_URL"))
 	if secretKey == "" || downloadPath == "" {
 		err := errors.New("ANNAS_SECRET_KEY and ANNAS_DOWNLOAD_PATH environment variables must be set")
 
@@ -31,7 +43,8 @@ func GetEnv() (*Env, error) {
 		l.Error("Environment variables not set",
 			zap.Bool("ANNAS_SECRET_KEY_set", secretKey != ""),
 			zap.String("ANNAS_DOWNLOAD_PATH", downloadPath),
-			zap.String("ANNAS_BASE_URL", annasBaseURL),
+			zap.String("ANNAS_FIXED_BASE_URL", fixedBaseURL),
+			zap.String("ANNAS_BASE_URL", fallbackBaseURL),
 			zap.Error(err),
 		)
 
@@ -42,8 +55,34 @@ func GetEnv() (*Env, error) {
 		return nil, fmt.Errorf("ANNAS_DOWNLOAD_PATH must be an absolute path, got: %s", downloadPath)
 	}
 
+	annasBaseURL := fixedBaseURL
+	if annasBaseURL == "" {
+		resolvedEnvOnce.Do(func() {
+			resolvedAnnasBaseURL, resolveAnnasBaseURLErr = resolveAnnasBaseURL()
+		})
+
+		if resolveAnnasBaseURLErr != nil {
+			l.Warn("Automatic Anna mirror resolution failed, using fallback mirror",
+				zap.String("ANNAS_BASE_URL", fallbackBaseURL),
+				zap.Error(resolveAnnasBaseURLErr),
+			)
+		}
+
+		annasBaseURL = normalizeBaseURL(resolvedAnnasBaseURL)
+	}
+
+	if annasBaseURL == "" {
+		annasBaseURL = fallbackBaseURL
+	}
+
 	if annasBaseURL == "" {
 		annasBaseURL = DefaultAnnasBaseURL
+	}
+
+	if fixedBaseURL != "" {
+		l.Info("Using fixed Anna mirror from ANNAS_FIXED_BASE_URL",
+			zap.String("ANNAS_FIXED_BASE_URL", fixedBaseURL),
+		)
 	}
 
 	return &Env{
@@ -51,4 +90,24 @@ func GetEnv() (*Env, error) {
 		DownloadPath: downloadPath,
 		AnnasBaseURL: annasBaseURL,
 	}, nil
+}
+
+func defaultResolveAnnasBaseURL() (string, error) {
+	fallbackBaseURL := normalizeBaseURL(os.Getenv("ANNAS_BASE_URL"))
+	resolver := mirror.NewResolver(nil, mirror.DefaultStatusPageURL, nil)
+	return resolver.Resolve(context.Background(), mirror.ResolveOptions{FallbackBaseURL: fallbackBaseURL})
+}
+
+func normalizeBaseURL(raw string) string {
+	value := strings.TrimSpace(raw)
+	value = strings.TrimSuffix(value, "/")
+	value = strings.TrimPrefix(value, "https://")
+	value = strings.TrimPrefix(value, "http://")
+	return value
+}
+
+func resetResolvedEnvForTests() {
+	resolvedEnvOnce = sync.Once{}
+	resolvedAnnasBaseURL = ""
+	resolveAnnasBaseURLErr = nil
 }

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -1,12 +1,17 @@
 package env
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
 
 	"github.com/iosifache/annas-mcp/internal/logger"
+	"github.com/iosifache/annas-mcp/internal/mirror"
 	"go.uber.org/zap"
 )
 
@@ -18,12 +23,44 @@ type Env struct {
 	AnnasBaseURL string `json:"annas_base_url"`
 }
 
+var (
+	resolvedEnvOnce        sync.Once
+	resolvedAnnasBaseURL   string
+	resolveAnnasBaseURLErr error
+	resolveAnnasBaseURL    = defaultResolveAnnasBaseURL
+)
+
 func GetAnnasBaseURL() string {
-	annasBaseURL := os.Getenv("ANNAS_BASE_URL")
-	if annasBaseURL == "" {
+	l := logger.GetLogger()
+
+	fallbackBaseURL := normalizeBaseURL(os.Getenv("ANNAS_BASE_URL"))
+	if !autoMirrorDiscoveryEnabled() {
+		if fallbackBaseURL != "" {
+			return fallbackBaseURL
+		}
 		return DefaultAnnasBaseURL
 	}
-	return annasBaseURL
+
+	resolvedEnvOnce.Do(func() {
+		resolvedAnnasBaseURL, resolveAnnasBaseURLErr = resolveAnnasBaseURL()
+	})
+
+	if resolveAnnasBaseURLErr != nil {
+		l.Warn("Automatic Anna mirror resolution failed, using configured mirror",
+			zap.String("ANNAS_BASE_URL", fallbackBaseURL),
+			zap.Error(resolveAnnasBaseURLErr),
+		)
+	}
+
+	if resolved := normalizeBaseURL(resolvedAnnasBaseURL); resolved != "" {
+		return resolved
+	}
+
+	if fallbackBaseURL != "" {
+		return fallbackBaseURL
+	}
+
+	return DefaultAnnasBaseURL
 }
 
 func GetEnv() (*Env, error) {
@@ -55,4 +92,29 @@ func GetEnv() (*Env, error) {
 		DownloadPath: downloadPath,
 		AnnasBaseURL: annasBaseURL,
 	}, nil
+}
+
+func defaultResolveAnnasBaseURL() (string, error) {
+	fallbackBaseURL := normalizeBaseURL(os.Getenv("ANNAS_BASE_URL"))
+	resolver := mirror.NewResolver(nil, mirror.DefaultStatusPageURL, nil)
+	return resolver.Resolve(context.Background(), mirror.ResolveOptions{FallbackBaseURL: fallbackBaseURL})
+}
+
+func autoMirrorDiscoveryEnabled() bool {
+	enabled, err := strconv.ParseBool(os.Getenv("ANNAS_AUTO_BASE_URL"))
+	return err == nil && enabled
+}
+
+func normalizeBaseURL(raw string) string {
+	value := strings.TrimSpace(raw)
+	value = strings.TrimSuffix(value, "/")
+	value = strings.TrimPrefix(value, "https://")
+	value = strings.TrimPrefix(value, "http://")
+	return value
+}
+
+func resetResolvedEnvForTests() {
+	resolvedEnvOnce = sync.Once{}
+	resolvedAnnasBaseURL = ""
+	resolveAnnasBaseURLErr = nil
 }

--- a/internal/env/env_test.go
+++ b/internal/env/env_test.go
@@ -1,0 +1,103 @@
+package env
+
+import (
+	"sync/atomic"
+	"testing"
+)
+
+func TestGetEnvUsesFixedBaseURLWithoutResolver(t *testing.T) {
+	t.Setenv("ANNAS_SECRET_KEY", "secret")
+	t.Setenv("ANNAS_DOWNLOAD_PATH", t.TempDir())
+	t.Setenv("ANNAS_FIXED_BASE_URL", "fixed.example")
+	t.Setenv("ANNAS_BASE_URL", "fallback.example")
+
+	resetResolvedEnvForTests()
+
+	resolverCalls := int32(0)
+	resolveAnnasBaseURL = func() (string, error) {
+		atomic.AddInt32(&resolverCalls, 1)
+		return "dynamic.example", nil
+	}
+	t.Cleanup(func() {
+		resolveAnnasBaseURL = defaultResolveAnnasBaseURL
+		resetResolvedEnvForTests()
+	})
+
+	cfg, err := GetEnv()
+	if err != nil {
+		t.Fatalf("GetEnv returned error: %v", err)
+	}
+
+	if cfg.AnnasBaseURL != "fixed.example" {
+		t.Fatalf("expected fixed.example, got %q", cfg.AnnasBaseURL)
+	}
+
+	if atomic.LoadInt32(&resolverCalls) != 0 {
+		t.Fatalf("expected resolver not to be called, got %d calls", resolverCalls)
+	}
+}
+
+func TestGetEnvCachesResolvedBaseURL(t *testing.T) {
+	t.Setenv("ANNAS_SECRET_KEY", "secret")
+	t.Setenv("ANNAS_DOWNLOAD_PATH", t.TempDir())
+	t.Setenv("ANNAS_BASE_URL", "fallback.example")
+
+	resetResolvedEnvForTests()
+
+	resolverCalls := int32(0)
+	resolveAnnasBaseURL = func() (string, error) {
+		atomic.AddInt32(&resolverCalls, 1)
+		return "dynamic.example", nil
+	}
+	t.Cleanup(func() {
+		resolveAnnasBaseURL = defaultResolveAnnasBaseURL
+		resetResolvedEnvForTests()
+	})
+
+	first, err := GetEnv()
+	if err != nil {
+		t.Fatalf("first GetEnv returned error: %v", err)
+	}
+
+	second, err := GetEnv()
+	if err != nil {
+		t.Fatalf("second GetEnv returned error: %v", err)
+	}
+
+	if first.AnnasBaseURL != "dynamic.example" || second.AnnasBaseURL != "dynamic.example" {
+		t.Fatalf("expected cached dynamic.example, got %q and %q", first.AnnasBaseURL, second.AnnasBaseURL)
+	}
+
+	if atomic.LoadInt32(&resolverCalls) != 1 {
+		t.Fatalf("expected resolver to be called once, got %d calls", resolverCalls)
+	}
+}
+
+func TestGetEnvFallsBackWhenResolverFails(t *testing.T) {
+	t.Setenv("ANNAS_SECRET_KEY", "secret")
+	t.Setenv("ANNAS_DOWNLOAD_PATH", t.TempDir())
+	t.Setenv("ANNAS_BASE_URL", "fallback.example")
+
+	resetResolvedEnvForTests()
+
+	resolveAnnasBaseURL = func() (string, error) {
+		return "", assertiveError("resolver failed")
+	}
+	t.Cleanup(func() {
+		resolveAnnasBaseURL = defaultResolveAnnasBaseURL
+		resetResolvedEnvForTests()
+	})
+
+	cfg, err := GetEnv()
+	if err != nil {
+		t.Fatalf("GetEnv returned error: %v", err)
+	}
+
+	if cfg.AnnasBaseURL != "fallback.example" {
+		t.Fatalf("expected fallback.example, got %q", cfg.AnnasBaseURL)
+	}
+}
+
+type assertiveError string
+
+func (e assertiveError) Error() string { return string(e) }

--- a/internal/env/env_test.go
+++ b/internal/env/env_test.go
@@ -1,0 +1,123 @@
+package env
+
+import (
+	"sync/atomic"
+	"testing"
+)
+
+func TestGetAnnasBaseURLDefaultsWithoutResolver(t *testing.T) {
+	resetResolvedEnvForTests()
+
+	resolverCalls := int32(0)
+	resolveAnnasBaseURL = func() (string, error) {
+		atomic.AddInt32(&resolverCalls, 1)
+		return "dynamic.example", nil
+	}
+	t.Cleanup(func() {
+		resolveAnnasBaseURL = defaultResolveAnnasBaseURL
+		resetResolvedEnvForTests()
+	})
+
+	baseURL := GetAnnasBaseURL()
+	if baseURL != DefaultAnnasBaseURL {
+		t.Fatalf("expected %q, got %q", DefaultAnnasBaseURL, baseURL)
+	}
+
+	if atomic.LoadInt32(&resolverCalls) != 0 {
+		t.Fatalf("expected resolver not to be called by default, got %d calls", resolverCalls)
+	}
+}
+
+func TestGetAnnasBaseURLUsesConfiguredBaseURLWithoutResolver(t *testing.T) {
+	t.Setenv("ANNAS_BASE_URL", "fallback.example")
+	resetResolvedEnvForTests()
+
+	resolverCalls := int32(0)
+	resolveAnnasBaseURL = func() (string, error) {
+		atomic.AddInt32(&resolverCalls, 1)
+		return "dynamic.example", nil
+	}
+	t.Cleanup(func() {
+		resolveAnnasBaseURL = defaultResolveAnnasBaseURL
+		resetResolvedEnvForTests()
+	})
+
+	baseURL := GetAnnasBaseURL()
+	if baseURL != "fallback.example" {
+		t.Fatalf("expected fallback.example, got %q", baseURL)
+	}
+
+	if atomic.LoadInt32(&resolverCalls) != 0 {
+		t.Fatalf("expected resolver not to be called unless auto discovery is enabled, got %d calls", resolverCalls)
+	}
+}
+
+func TestGetAnnasBaseURLCachesResolvedBaseURLWhenAutoEnabled(t *testing.T) {
+	t.Setenv("ANNAS_AUTO_BASE_URL", "true")
+	t.Setenv("ANNAS_BASE_URL", "fallback.example")
+
+	resetResolvedEnvForTests()
+
+	resolverCalls := int32(0)
+	resolveAnnasBaseURL = func() (string, error) {
+		atomic.AddInt32(&resolverCalls, 1)
+		return "dynamic.example", nil
+	}
+	t.Cleanup(func() {
+		resolveAnnasBaseURL = defaultResolveAnnasBaseURL
+		resetResolvedEnvForTests()
+	})
+
+	first := GetAnnasBaseURL()
+	second := GetAnnasBaseURL()
+
+	if first != "dynamic.example" || second != "dynamic.example" {
+		t.Fatalf("expected cached dynamic.example, got %q and %q", first, second)
+	}
+
+	if atomic.LoadInt32(&resolverCalls) != 1 {
+		t.Fatalf("expected resolver to be called once, got %d calls", resolverCalls)
+	}
+}
+
+func TestGetAnnasBaseURLFallsBackWhenAutoResolverFails(t *testing.T) {
+	t.Setenv("ANNAS_AUTO_BASE_URL", "true")
+	t.Setenv("ANNAS_BASE_URL", "fallback.example")
+
+	resetResolvedEnvForTests()
+
+	resolveAnnasBaseURL = func() (string, error) {
+		return "", assertiveError("resolver failed")
+	}
+	t.Cleanup(func() {
+		resolveAnnasBaseURL = defaultResolveAnnasBaseURL
+		resetResolvedEnvForTests()
+	})
+
+	baseURL := GetAnnasBaseURL()
+	if baseURL != "fallback.example" {
+		t.Fatalf("expected fallback.example, got %q", baseURL)
+	}
+}
+
+func TestGetEnvUsesSelectedBaseURL(t *testing.T) {
+	t.Setenv("ANNAS_SECRET_KEY", "secret")
+	t.Setenv("ANNAS_DOWNLOAD_PATH", t.TempDir())
+	t.Setenv("ANNAS_BASE_URL", "configured.example")
+
+	resetResolvedEnvForTests()
+	t.Cleanup(resetResolvedEnvForTests)
+
+	cfg, err := GetEnv()
+	if err != nil {
+		t.Fatalf("GetEnv returned error: %v", err)
+	}
+
+	if cfg.AnnasBaseURL != "configured.example" {
+		t.Fatalf("expected configured.example, got %q", cfg.AnnasBaseURL)
+	}
+}
+
+type assertiveError string
+
+func (e assertiveError) Error() string { return string(e) }

--- a/internal/mirror/mirror_test.go
+++ b/internal/mirror/mirror_test.go
@@ -1,0 +1,181 @@
+package mirror
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestParseStatusPageExtractsAnnaCandidatesWithoutHardcodedIDs(t *testing.T) {
+	t.Parallel()
+
+	html := `
+<html><body>
+<script>
+window.preloadData = {'config':{'slug':'slum'},'incident':null,'publicGroupList':[
+  {'id':1,'name':'Anna\'s Archive','monitorList':[
+    {'id':900,'name':'Anna A','sendUrl':1,'type':'keyword','url':'https://annas-archive.zz/'},
+    {'id':901,'name':'Anna B','sendUrl':1,'type':'keyword','url':'https://annas-archive.yy/'}
+  ]},
+  {'id':2,'name':'Others','monitorList':[
+    {'id':999,'name':'Not Anna','sendUrl':1,'type':'keyword','url':'https://example.org/'}
+  ]}
+],'maintenanceList':[]};
+</script>
+</body></html>`
+
+	candidates, err := ParseStatusPageHTML(html)
+	if err != nil {
+		t.Fatalf("ParseStatusPageHTML returned error: %v", err)
+	}
+
+	if len(candidates) != 2 {
+		t.Fatalf("expected 2 Anna candidates, got %d", len(candidates))
+	}
+
+	if candidates[0].MonitorID != 900 || candidates[0].BaseURL != "annas-archive.zz" {
+		t.Fatalf("unexpected first candidate: %+v", candidates[0])
+	}
+
+	if candidates[1].MonitorID != 901 || candidates[1].BaseURL != "annas-archive.yy" {
+		t.Fatalf("unexpected second candidate: %+v", candidates[1])
+	}
+}
+
+func TestResolveBestBaseURLPrefersHealthyFastCandidateAndSkipsFailedProbe(t *testing.T) {
+	t.Parallel()
+
+	html := `
+<script>
+window.preloadData = {'config':{'slug':'slum'},'incident':null,'publicGroupList':[
+  {'id':1,'name':'Anna\'s Archive','monitorList':[
+    {'id':10,'name':'Slow','sendUrl':1,'type':'keyword','url':'https://annas-archive.slow/'},
+    {'id':20,'name':'FastButProbeFails','sendUrl':1,'type':'keyword','url':'https://annas-archive.fail/'},
+    {'id':30,'name':'FastHealthy','sendUrl':1,'type':'keyword','url':'https://annas-archive.good/'}
+  ]}
+],'maintenanceList':[]};
+</script>`
+
+	heartbeatJSON := `{
+		"heartbeatList": {
+			"10": [
+				{"status": 1, "time": "2026-03-23 10:00:00", "ping": 900},
+				{"status": 1, "time": "2026-03-23 10:01:00", "ping": 800}
+			],
+			"20": [
+				{"status": 1, "time": "2026-03-23 10:00:00", "ping": 100},
+				{"status": 1, "time": "2026-03-23 10:01:00", "ping": 110}
+			],
+			"30": [
+				{"status": 1, "time": "2026-03-23 10:00:00", "ping": 150},
+				{"status": 1, "time": "2026-03-23 10:01:00", "ping": 140}
+			]
+		},
+		"uptimeList": {}
+	}`
+
+	client := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			switch req.URL.String() {
+			case "https://status.example/":
+				return stringResponse(req, http.StatusOK, html), nil
+			case "https://status.example/api/status-page/heartbeat/slum":
+				return stringResponse(req, http.StatusOK, heartbeatJSON), nil
+			default:
+				return nil, errors.New("unexpected request: " + req.URL.String())
+			}
+		}),
+	}
+
+	probeCalls := make([]string, 0)
+	resolver := NewResolver(client, "https://status.example/", func(ctx context.Context, baseURL string) error {
+		probeCalls = append(probeCalls, baseURL)
+		if baseURL == "annas-archive.fail" {
+			return errors.New("probe failed")
+		}
+		return nil
+	})
+
+	baseURL, err := resolver.Resolve(context.Background(), ResolveOptions{FallbackBaseURL: "fallback.example"})
+	if err != nil {
+		t.Fatalf("Resolve returned error: %v", err)
+	}
+
+	if baseURL != "annas-archive.good" {
+		t.Fatalf("expected annas-archive.good, got %q", baseURL)
+	}
+
+	if len(probeCalls) == 0 {
+		t.Fatal("expected probe to be called")
+	}
+}
+
+func TestResolveFallsBackWhenStatusPageFails(t *testing.T) {
+	t.Parallel()
+
+	client := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return nil, errors.New("network down")
+		}),
+	}
+
+	resolver := NewResolver(client, "https://status.example/", func(ctx context.Context, baseURL string) error {
+		return nil
+	})
+
+	baseURL, err := resolver.Resolve(context.Background(), ResolveOptions{FallbackBaseURL: "fallback.example"})
+	if err != nil {
+		t.Fatalf("Resolve returned error: %v", err)
+	}
+
+	if baseURL != "fallback.example" {
+		t.Fatalf("expected fallback.example, got %q", baseURL)
+	}
+}
+
+func stringResponse(req *http.Request, status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Status:     http.StatusText(status),
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
+		Request:    req,
+	}
+}
+
+func TestCandidateScoreUsesRecentHeartbeatQuality(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 3, 23, 11, 0, 0, 0, time.UTC)
+	candidate := Candidate{
+		BaseURL: "annas-archive.good",
+		Heartbeats: []Heartbeat{
+			{Status: 1, Ping: 200, Time: now.Add(-2 * time.Minute)},
+			{Status: 1, Ping: 100, Time: now.Add(-1 * time.Minute)},
+			{Status: 0, Ping: 0, Time: now},
+		},
+	}
+
+	score := candidate.Score()
+	if score.SuccessCount != 2 {
+		t.Fatalf("expected 2 successful heartbeats, got %d", score.SuccessCount)
+	}
+
+	if score.LastStatus != 0 {
+		t.Fatalf("expected last status 0, got %d", score.LastStatus)
+	}
+
+	if score.AveragePing != 150 {
+		t.Fatalf("expected average ping 150, got %d", score.AveragePing)
+	}
+}

--- a/internal/mirror/mirror_test.go
+++ b/internal/mirror/mirror_test.go
@@ -1,0 +1,217 @@
+package mirror
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestParseStatusPageExtractsAnnaCandidatesWithoutHardcodedIDs(t *testing.T) {
+	t.Parallel()
+
+	html := `
+<html><body>
+<script>
+window.preloadData = {'config':{'slug':'slum'},'incident':null,'publicGroupList':[
+  {'id':1,'name':'Anna\'s Archive','monitorList':[
+    {'id':900,'name':'Anna A','sendUrl':1,'type':'keyword','url':'https://annas-archive.zz/'},
+    {'id':901,'name':'Anna B','sendUrl':1,'type':'keyword','url':'https://annas-archive.yy/'}
+  ]},
+  {'id':2,'name':'Others','monitorList':[
+    {'id':999,'name':'Not Anna','sendUrl':1,'type':'keyword','url':'https://example.org/'}
+  ]}
+],'maintenanceList':[]};
+</script>
+</body></html>`
+
+	candidates, err := ParseStatusPageHTML(html)
+	if err != nil {
+		t.Fatalf("ParseStatusPageHTML returned error: %v", err)
+	}
+
+	if len(candidates) != 2 {
+		t.Fatalf("expected 2 Anna candidates, got %d", len(candidates))
+	}
+
+	if candidates[0].MonitorID != 900 || candidates[0].BaseURL != "annas-archive.zz" {
+		t.Fatalf("unexpected first candidate: %+v", candidates[0])
+	}
+
+	if candidates[1].MonitorID != 901 || candidates[1].BaseURL != "annas-archive.yy" {
+		t.Fatalf("unexpected second candidate: %+v", candidates[1])
+	}
+}
+
+func TestResolveBestBaseURLPrefersHealthyFastCandidateAndSkipsFailedProbe(t *testing.T) {
+	t.Parallel()
+
+	html := `
+<script>
+window.preloadData = {'config':{'slug':'slum'},'incident':null,'publicGroupList':[
+  {'id':1,'name':'Anna\'s Archive','monitorList':[
+    {'id':10,'name':'Slow','sendUrl':1,'type':'keyword','url':'https://annas-archive.slow/'},
+    {'id':20,'name':'FastButProbeFails','sendUrl':1,'type':'keyword','url':'https://annas-archive.fail/'},
+    {'id':30,'name':'FastHealthy','sendUrl':1,'type':'keyword','url':'https://annas-archive.good/'}
+  ]}
+],'maintenanceList':[]};
+</script>`
+
+	heartbeatJSON := `{
+		"heartbeatList": {
+			"10": [
+				{"status": 1, "time": "2026-03-23 10:00:00", "ping": 900},
+				{"status": 1, "time": "2026-03-23 10:01:00", "ping": 800}
+			],
+			"20": [
+				{"status": 1, "time": "2026-03-23 10:00:00", "ping": 100},
+				{"status": 1, "time": "2026-03-23 10:01:00", "ping": 110}
+			],
+			"30": [
+				{"status": 1, "time": "2026-03-23 10:00:00", "ping": 150},
+				{"status": 1, "time": "2026-03-23 10:01:00", "ping": 140}
+			]
+		},
+		"uptimeList": {}
+	}`
+
+	client := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			switch req.URL.String() {
+			case "https://status.example/":
+				return stringResponse(req, http.StatusOK, html), nil
+			case "https://status.example/api/status-page/heartbeat/slum":
+				return stringResponse(req, http.StatusOK, heartbeatJSON), nil
+			default:
+				return nil, errors.New("unexpected request: " + req.URL.String())
+			}
+		}),
+	}
+
+	probeCalls := make([]string, 0)
+	resolver := NewResolver(client, "https://status.example/", func(ctx context.Context, baseURL string) error {
+		probeCalls = append(probeCalls, baseURL)
+		if baseURL == "annas-archive.fail" {
+			return errors.New("probe failed")
+		}
+		return nil
+	})
+
+	baseURL, err := resolver.Resolve(context.Background(), ResolveOptions{FallbackBaseURL: "fallback.example"})
+	if err != nil {
+		t.Fatalf("Resolve returned error: %v", err)
+	}
+
+	if baseURL != "annas-archive.good" {
+		t.Fatalf("expected annas-archive.good, got %q", baseURL)
+	}
+
+	if len(probeCalls) == 0 {
+		t.Fatal("expected probe to be called")
+	}
+}
+
+func TestResolveProbesURLFallbackCandidatesWithoutHeartbeatData(t *testing.T) {
+	t.Parallel()
+
+	html := `<html><body><a href="https://annas-archive.fallback/">mirror</a></body></html>`
+	heartbeatJSON := `{"heartbeatList":{},"uptimeList":{}}`
+
+	client := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			switch req.URL.String() {
+			case "https://status.example/":
+				return stringResponse(req, http.StatusOK, html), nil
+			case "https://status.example/api/status-page/heartbeat/slum":
+				return stringResponse(req, http.StatusOK, heartbeatJSON), nil
+			default:
+				return nil, errors.New("unexpected request: " + req.URL.String())
+			}
+		}),
+	}
+
+	resolver := NewResolver(client, "https://status.example/", func(ctx context.Context, baseURL string) error {
+		if baseURL != "annas-archive.fallback" {
+			return errors.New("unexpected probe: " + baseURL)
+		}
+		return nil
+	})
+
+	baseURL, err := resolver.Resolve(context.Background(), ResolveOptions{})
+	if err != nil {
+		t.Fatalf("Resolve returned error: %v", err)
+	}
+
+	if baseURL != "annas-archive.fallback" {
+		t.Fatalf("expected annas-archive.fallback, got %q", baseURL)
+	}
+}
+
+func TestResolveFallsBackWhenStatusPageFails(t *testing.T) {
+	t.Parallel()
+
+	client := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return nil, errors.New("network down")
+		}),
+	}
+
+	resolver := NewResolver(client, "https://status.example/", func(ctx context.Context, baseURL string) error {
+		return nil
+	})
+
+	baseURL, err := resolver.Resolve(context.Background(), ResolveOptions{FallbackBaseURL: "fallback.example"})
+	if err != nil {
+		t.Fatalf("Resolve returned error: %v", err)
+	}
+
+	if baseURL != "fallback.example" {
+		t.Fatalf("expected fallback.example, got %q", baseURL)
+	}
+}
+
+func stringResponse(req *http.Request, status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Status:     http.StatusText(status),
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
+		Request:    req,
+	}
+}
+
+func TestCandidateScoreUsesRecentHeartbeatQuality(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 3, 23, 11, 0, 0, 0, time.UTC)
+	candidate := Candidate{
+		BaseURL: "annas-archive.good",
+		Heartbeats: []Heartbeat{
+			{Status: 1, Ping: 200, Time: now.Add(-2 * time.Minute)},
+			{Status: 1, Ping: 100, Time: now.Add(-1 * time.Minute)},
+			{Status: 0, Ping: 0, Time: now},
+		},
+	}
+
+	score := candidate.Score()
+	if score.SuccessCount != 2 {
+		t.Fatalf("expected 2 successful heartbeats, got %d", score.SuccessCount)
+	}
+
+	if score.LastStatus != 0 {
+		t.Fatalf("expected last status 0, got %d", score.LastStatus)
+	}
+
+	if score.AveragePing != 150 {
+		t.Fatalf("expected average ping 150, got %d", score.AveragePing)
+	}
+}

--- a/internal/mirror/resolver.go
+++ b/internal/mirror/resolver.go
@@ -1,0 +1,463 @@
+package mirror
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/iosifache/annas-mcp/internal/logger"
+	"go.uber.org/zap"
+)
+
+const (
+	DefaultStatusPageURL  = "https://open-slum.org/"
+	defaultStatusPageSlug = "slum"
+	defaultProbeTimeout   = 10 * time.Second
+	browserUserAgent      = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+)
+
+var (
+	slugRegex            = regexp.MustCompile(`['"]slug['"]\s*:\s*['"]([^'"]+)['"]`)
+	candidateObjectRegex = regexp.MustCompile(`(?s)\{[^{}]*['"]id['"]\s*:\s*([0-9]+)[^{}]*['"]url['"]\s*:\s*['"]([^'"]+)['"][^{}]*\}`)
+	fallbackURLRegex     = regexp.MustCompile(`https://annas-archive\.[a-z0-9-]+/?`)
+)
+
+type Heartbeat struct {
+	Status    int       `json:"status"`
+	Ping      int64     `json:"ping"`
+	Time      time.Time `json:"-"`
+	Timestamp string    `json:"time"`
+}
+
+type Candidate struct {
+	MonitorID  int
+	BaseURL    string
+	SourceURL  string
+	Heartbeats []Heartbeat
+}
+
+type CandidateScore struct {
+	SuccessCount int
+	SampleCount  int
+	LastStatus   int
+	AveragePing  int64
+}
+
+type ResolveOptions struct {
+	FallbackBaseURL string
+}
+
+type ProbeFunc func(context.Context, string) error
+
+type Resolver struct {
+	client        *http.Client
+	statusPageURL string
+	probe         ProbeFunc
+}
+
+type heartbeatEnvelope struct {
+	HeartbeatList map[string][]Heartbeat `json:"heartbeatList"`
+}
+
+func NewResolver(client *http.Client, statusPageURL string, probe ProbeFunc) *Resolver {
+	if client == nil {
+		client = &http.Client{Timeout: defaultProbeTimeout}
+	}
+
+	if statusPageURL == "" {
+		statusPageURL = DefaultStatusPageURL
+	}
+
+	resolver := &Resolver{
+		client:        client,
+		statusPageURL: statusPageURL,
+	}
+
+	if probe == nil {
+		resolver.probe = resolver.defaultProbe
+	} else {
+		resolver.probe = probe
+	}
+
+	return resolver
+}
+
+func NormalizeBaseURL(raw string) string {
+	value := strings.TrimSpace(raw)
+	value = strings.TrimSuffix(value, "/")
+	value = strings.TrimPrefix(value, "https://")
+	value = strings.TrimPrefix(value, "http://")
+	return value
+}
+
+func ParseStatusPageHTML(html string) ([]Candidate, error) {
+	normalized := strings.ReplaceAll(html, `\'`, `'`)
+
+	candidates, err := parseCandidatesFromAnnaGroup(normalized)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(candidates) > 0 {
+		return candidates, nil
+	}
+
+	return parseCandidatesByURLFallback(normalized), nil
+}
+
+func (c Candidate) Score() CandidateScore {
+	score := CandidateScore{
+		SampleCount: len(c.Heartbeats),
+		LastStatus:  -1,
+	}
+
+	var pingSum int64
+	for idx, hb := range c.Heartbeats {
+		if idx == len(c.Heartbeats)-1 {
+			score.LastStatus = hb.Status
+		}
+
+		if hb.Status == 1 {
+			score.SuccessCount++
+			pingSum += hb.Ping
+		}
+	}
+
+	if score.SuccessCount > 0 {
+		score.AveragePing = pingSum / int64(score.SuccessCount)
+	}
+
+	return score
+}
+
+func (r *Resolver) Resolve(ctx context.Context, opts ResolveOptions) (string, error) {
+	l := logger.GetLogger()
+	fallbackBaseURL := NormalizeBaseURL(opts.FallbackBaseURL)
+
+	html, err := r.fetch(ctx, r.statusPageURL)
+	if err != nil {
+		l.Warn("Failed to fetch mirror status page, using fallback mirror if available",
+			zap.String("statusPageURL", r.statusPageURL),
+			zap.String("fallbackBaseURL", fallbackBaseURL),
+			zap.Error(err),
+		)
+		if fallbackBaseURL != "" {
+			return fallbackBaseURL, nil
+		}
+		return "", err
+	}
+
+	candidates, err := ParseStatusPageHTML(html)
+	if err != nil || len(candidates) == 0 {
+		l.Warn("Failed to discover Anna mirror candidates, using fallback mirror if available",
+			zap.Int("candidateCount", len(candidates)),
+			zap.String("fallbackBaseURL", fallbackBaseURL),
+			zap.Error(err),
+		)
+		if fallbackBaseURL != "" {
+			return fallbackBaseURL, nil
+		}
+		if err == nil {
+			err = errors.New("no Anna mirror candidates discovered")
+		}
+		return "", err
+	}
+
+	slug := extractStatusPageSlug(html)
+	heartbeatURL, err := buildHeartbeatURL(r.statusPageURL, slug)
+	if err != nil {
+		if fallbackBaseURL != "" {
+			return fallbackBaseURL, nil
+		}
+		return "", err
+	}
+
+	heartbeatJSON, err := r.fetch(ctx, heartbeatURL)
+	if err != nil {
+		l.Warn("Failed to fetch mirror heartbeat data, using fallback mirror if available",
+			zap.String("heartbeatURL", heartbeatURL),
+			zap.String("fallbackBaseURL", fallbackBaseURL),
+			zap.Error(err),
+		)
+		if fallbackBaseURL != "" {
+			return fallbackBaseURL, nil
+		}
+		return "", err
+	}
+
+	envelope := heartbeatEnvelope{}
+	if err := json.Unmarshal([]byte(heartbeatJSON), &envelope); err != nil {
+		l.Warn("Failed to decode mirror heartbeat data, using fallback mirror if available",
+			zap.String("fallbackBaseURL", fallbackBaseURL),
+			zap.Error(err),
+		)
+		if fallbackBaseURL != "" {
+			return fallbackBaseURL, nil
+		}
+		return "", err
+	}
+
+	ranked := rankCandidates(applyHeartbeats(candidates, envelope.HeartbeatList))
+	l.Info("Resolved Anna mirror candidates",
+		zap.Int("discoveredCandidates", len(candidates)),
+		zap.Int("healthyCandidates", len(ranked)),
+	)
+	for _, candidate := range ranked {
+		if r.probe != nil {
+			if err := r.probe(ctx, candidate.BaseURL); err != nil {
+				l.Warn("Anna mirror probe failed",
+					zap.String("baseURL", candidate.BaseURL),
+					zap.Error(err),
+				)
+				continue
+			}
+		}
+
+		l.Info("Selected Anna mirror automatically",
+			zap.String("baseURL", candidate.BaseURL),
+			zap.Int("monitorID", candidate.MonitorID),
+		)
+		return candidate.BaseURL, nil
+	}
+
+	if fallbackBaseURL != "" {
+		l.Warn("No reachable Anna mirror found, using fallback mirror",
+			zap.String("fallbackBaseURL", fallbackBaseURL),
+		)
+		return fallbackBaseURL, nil
+	}
+
+	return "", errors.New("no reachable Anna mirror found")
+}
+
+func (r *Resolver) defaultProbe(ctx context.Context, baseURL string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("https://%s/search?q=test&content=book_any", NormalizeBaseURL(baseURL)), nil)
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("User-Agent", browserUserAgent)
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusBadRequest {
+		return fmt.Errorf("probe failed with status %d", resp.StatusCode)
+	}
+
+	return nil
+}
+
+func (r *Resolver) fetch(ctx context.Context, rawURL string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return "", err
+	}
+
+	req.Header.Set("User-Agent", browserUserAgent)
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return "", fmt.Errorf("unexpected status %d for %s", resp.StatusCode, rawURL)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	return string(body), nil
+}
+
+func parseCandidatesFromAnnaGroup(html string) ([]Candidate, error) {
+	groupIndex := strings.Index(html, "Anna's Archive")
+	if groupIndex < 0 {
+		return nil, nil
+	}
+
+	monitorKeyIndex := strings.Index(html[groupIndex:], "'monitorList':[")
+	if monitorKeyIndex < 0 {
+		monitorKeyIndex = strings.Index(html[groupIndex:], `"monitorList":[`)
+	}
+	if monitorKeyIndex < 0 {
+		return nil, errors.New("Anna group found but monitor list missing")
+	}
+
+	monitorKeyIndex += groupIndex
+	listStart := strings.Index(html[monitorKeyIndex:], "[")
+	if listStart < 0 {
+		return nil, errors.New("monitor list start missing")
+	}
+
+	listStart += monitorKeyIndex
+	listEnd := findMatchingBracket(html, listStart)
+	if listEnd < 0 {
+		return nil, errors.New("monitor list end missing")
+	}
+
+	return parseCandidatesFromSection(html[listStart : listEnd+1]), nil
+}
+
+func parseCandidatesByURLFallback(html string) []Candidate {
+	matches := fallbackURLRegex.FindAllString(html, -1)
+	seen := make(map[string]struct{})
+	candidates := make([]Candidate, 0, len(matches))
+
+	for _, match := range matches {
+		baseURL := NormalizeBaseURL(match)
+		if _, exists := seen[baseURL]; exists {
+			continue
+		}
+		seen[baseURL] = struct{}{}
+		candidates = append(candidates, Candidate{
+			BaseURL:   baseURL,
+			SourceURL: "https://" + baseURL + "/",
+		})
+	}
+
+	return candidates
+}
+
+func parseCandidatesFromSection(section string) []Candidate {
+	matches := candidateObjectRegex.FindAllStringSubmatch(section, -1)
+	candidates := make([]Candidate, 0, len(matches))
+	seen := make(map[string]struct{})
+
+	for _, match := range matches {
+		if len(match) < 3 {
+			continue
+		}
+
+		baseURL := NormalizeBaseURL(match[2])
+		if !strings.HasPrefix(baseURL, "annas-archive.") {
+			continue
+		}
+
+		if _, exists := seen[baseURL]; exists {
+			continue
+		}
+
+		seen[baseURL] = struct{}{}
+		candidates = append(candidates, Candidate{
+			MonitorID: mustAtoi(match[1]),
+			BaseURL:   baseURL,
+			SourceURL: match[2],
+		})
+	}
+
+	return candidates
+}
+
+func applyHeartbeats(candidates []Candidate, heartbeatList map[string][]Heartbeat) []Candidate {
+	enriched := make([]Candidate, 0, len(candidates))
+
+	for _, candidate := range candidates {
+		if candidate.MonitorID > 0 {
+			candidate.Heartbeats = heartbeatList[fmt.Sprintf("%d", candidate.MonitorID)]
+		}
+		enriched = append(enriched, candidate)
+	}
+
+	return enriched
+}
+
+func rankCandidates(candidates []Candidate) []Candidate {
+	filtered := make([]Candidate, 0, len(candidates))
+	for _, candidate := range candidates {
+		score := candidate.Score()
+		if score.LastStatus == 1 {
+			filtered = append(filtered, candidate)
+		}
+	}
+
+	sort.SliceStable(filtered, func(i, j int) bool {
+		left := filtered[i].Score()
+		right := filtered[j].Score()
+
+		leftRate := successRate(left)
+		rightRate := successRate(right)
+		if leftRate != rightRate {
+			return leftRate > rightRate
+		}
+
+		if left.AveragePing != right.AveragePing {
+			return left.AveragePing < right.AveragePing
+		}
+
+		return filtered[i].BaseURL < filtered[j].BaseURL
+	})
+
+	return filtered
+}
+
+func successRate(score CandidateScore) float64 {
+	if score.SampleCount == 0 {
+		return 0
+	}
+
+	return float64(score.SuccessCount) / float64(score.SampleCount)
+}
+
+func extractStatusPageSlug(html string) string {
+	match := slugRegex.FindStringSubmatch(strings.ReplaceAll(html, `\'`, `'`))
+	if len(match) == 2 {
+		return match[1]
+	}
+
+	return defaultStatusPageSlug
+}
+
+func buildHeartbeatURL(statusPageURL, slug string) (string, error) {
+	parsed, err := url.Parse(statusPageURL)
+	if err != nil {
+		return "", err
+	}
+
+	heartbeatPath := fmt.Sprintf("/api/status-page/heartbeat/%s", slug)
+	parsed.Path = heartbeatPath
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+
+	return parsed.String(), nil
+}
+
+func findMatchingBracket(input string, start int) int {
+	depth := 0
+	for idx := start; idx < len(input); idx++ {
+		switch input[idx] {
+		case '[':
+			depth++
+		case ']':
+			depth--
+			if depth == 0 {
+				return idx
+			}
+		}
+	}
+
+	return -1
+}
+
+func mustAtoi(raw string) int {
+	value := 0
+	for _, ch := range raw {
+		value = value*10 + int(ch-'0')
+	}
+	return value
+}

--- a/internal/mirror/resolver.go
+++ b/internal/mirror/resolver.go
@@ -1,0 +1,470 @@
+package mirror
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/iosifache/annas-mcp/internal/logger"
+	"go.uber.org/zap"
+)
+
+const (
+	DefaultStatusPageURL  = "https://open-slum.org/"
+	defaultStatusPageSlug = "slum"
+	defaultProbeTimeout   = 10 * time.Second
+	browserUserAgent      = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+)
+
+var (
+	slugRegex            = regexp.MustCompile(`['"]slug['"]\s*:\s*['"]([^'"]+)['"]`)
+	candidateObjectRegex = regexp.MustCompile(`(?s)\{[^{}]*['"]id['"]\s*:\s*([0-9]+)[^{}]*['"]url['"]\s*:\s*['"]([^'"]+)['"][^{}]*\}`)
+	fallbackURLRegex     = regexp.MustCompile(`https://annas-archive\.[a-z0-9-]+/?`)
+)
+
+type Heartbeat struct {
+	Status    int       `json:"status"`
+	Ping      int64     `json:"ping"`
+	Time      time.Time `json:"-"`
+	Timestamp string    `json:"time"`
+}
+
+type Candidate struct {
+	MonitorID  int
+	BaseURL    string
+	SourceURL  string
+	Heartbeats []Heartbeat
+}
+
+type CandidateScore struct {
+	SuccessCount int
+	SampleCount  int
+	LastStatus   int
+	AveragePing  int64
+}
+
+type ResolveOptions struct {
+	FallbackBaseURL string
+}
+
+type ProbeFunc func(context.Context, string) error
+
+type Resolver struct {
+	client        *http.Client
+	statusPageURL string
+	probe         ProbeFunc
+}
+
+type heartbeatEnvelope struct {
+	HeartbeatList map[string][]Heartbeat `json:"heartbeatList"`
+}
+
+func NewResolver(client *http.Client, statusPageURL string, probe ProbeFunc) *Resolver {
+	if client == nil {
+		client = &http.Client{Timeout: defaultProbeTimeout}
+	}
+
+	if statusPageURL == "" {
+		statusPageURL = DefaultStatusPageURL
+	}
+
+	resolver := &Resolver{
+		client:        client,
+		statusPageURL: statusPageURL,
+	}
+
+	if probe == nil {
+		resolver.probe = resolver.defaultProbe
+	} else {
+		resolver.probe = probe
+	}
+
+	return resolver
+}
+
+func NormalizeBaseURL(raw string) string {
+	value := strings.TrimSpace(raw)
+	value = strings.TrimSuffix(value, "/")
+	value = strings.TrimPrefix(value, "https://")
+	value = strings.TrimPrefix(value, "http://")
+	return value
+}
+
+func ParseStatusPageHTML(html string) ([]Candidate, error) {
+	normalized := strings.ReplaceAll(html, `\'`, `'`)
+
+	candidates, err := parseCandidatesFromAnnaGroup(normalized)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(candidates) > 0 {
+		return candidates, nil
+	}
+
+	return parseCandidatesByURLFallback(normalized), nil
+}
+
+func (c Candidate) Score() CandidateScore {
+	score := CandidateScore{
+		SampleCount: len(c.Heartbeats),
+		LastStatus:  -1,
+	}
+
+	var pingSum int64
+	for idx, hb := range c.Heartbeats {
+		if idx == len(c.Heartbeats)-1 {
+			score.LastStatus = hb.Status
+		}
+
+		if hb.Status == 1 {
+			score.SuccessCount++
+			pingSum += hb.Ping
+		}
+	}
+
+	if score.SuccessCount > 0 {
+		score.AveragePing = pingSum / int64(score.SuccessCount)
+	}
+
+	return score
+}
+
+func (r *Resolver) Resolve(ctx context.Context, opts ResolveOptions) (string, error) {
+	l := logger.GetLogger()
+	fallbackBaseURL := NormalizeBaseURL(opts.FallbackBaseURL)
+
+	html, err := r.fetch(ctx, r.statusPageURL)
+	if err != nil {
+		l.Warn("Failed to fetch mirror status page, using fallback mirror if available",
+			zap.String("statusPageURL", r.statusPageURL),
+			zap.String("fallbackBaseURL", fallbackBaseURL),
+			zap.Error(err),
+		)
+		if fallbackBaseURL != "" {
+			return fallbackBaseURL, nil
+		}
+		return "", err
+	}
+
+	candidates, err := ParseStatusPageHTML(html)
+	if err != nil || len(candidates) == 0 {
+		l.Warn("Failed to discover Anna mirror candidates, using fallback mirror if available",
+			zap.Int("candidateCount", len(candidates)),
+			zap.String("fallbackBaseURL", fallbackBaseURL),
+			zap.Error(err),
+		)
+		if fallbackBaseURL != "" {
+			return fallbackBaseURL, nil
+		}
+		if err == nil {
+			err = errors.New("no Anna mirror candidates discovered")
+		}
+		return "", err
+	}
+
+	slug := extractStatusPageSlug(html)
+	heartbeatURL, err := buildHeartbeatURL(r.statusPageURL, slug)
+	if err != nil {
+		if fallbackBaseURL != "" {
+			return fallbackBaseURL, nil
+		}
+		return "", err
+	}
+
+	heartbeatJSON, err := r.fetch(ctx, heartbeatURL)
+	if err != nil {
+		l.Warn("Failed to fetch mirror heartbeat data, using fallback mirror if available",
+			zap.String("heartbeatURL", heartbeatURL),
+			zap.String("fallbackBaseURL", fallbackBaseURL),
+			zap.Error(err),
+		)
+		if fallbackBaseURL != "" {
+			return fallbackBaseURL, nil
+		}
+		return "", err
+	}
+
+	envelope := heartbeatEnvelope{}
+	if err := json.Unmarshal([]byte(heartbeatJSON), &envelope); err != nil {
+		l.Warn("Failed to decode mirror heartbeat data, using fallback mirror if available",
+			zap.String("fallbackBaseURL", fallbackBaseURL),
+			zap.Error(err),
+		)
+		if fallbackBaseURL != "" {
+			return fallbackBaseURL, nil
+		}
+		return "", err
+	}
+
+	ranked := rankCandidates(applyHeartbeats(candidates, envelope.HeartbeatList))
+	l.Info("Resolved Anna mirror candidates",
+		zap.Int("discoveredCandidates", len(candidates)),
+		zap.Int("healthyCandidates", len(ranked)),
+	)
+	for _, candidate := range ranked {
+		if r.probe != nil {
+			if err := r.probe(ctx, candidate.BaseURL); err != nil {
+				l.Warn("Anna mirror probe failed",
+					zap.String("baseURL", candidate.BaseURL),
+					zap.Error(err),
+				)
+				continue
+			}
+		}
+
+		l.Info("Selected Anna mirror automatically",
+			zap.String("baseURL", candidate.BaseURL),
+			zap.Int("monitorID", candidate.MonitorID),
+		)
+		return candidate.BaseURL, nil
+	}
+
+	if fallbackBaseURL != "" {
+		l.Warn("No reachable Anna mirror found, using fallback mirror",
+			zap.String("fallbackBaseURL", fallbackBaseURL),
+		)
+		return fallbackBaseURL, nil
+	}
+
+	return "", errors.New("no reachable Anna mirror found")
+}
+
+func (r *Resolver) defaultProbe(ctx context.Context, baseURL string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("https://%s/search?q=test&content=book_any", NormalizeBaseURL(baseURL)), nil)
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("User-Agent", browserUserAgent)
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusBadRequest {
+		return fmt.Errorf("probe failed with status %d", resp.StatusCode)
+	}
+
+	return nil
+}
+
+func (r *Resolver) fetch(ctx context.Context, rawURL string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return "", err
+	}
+
+	req.Header.Set("User-Agent", browserUserAgent)
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return "", fmt.Errorf("unexpected status %d for %s", resp.StatusCode, rawURL)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	return string(body), nil
+}
+
+func parseCandidatesFromAnnaGroup(html string) ([]Candidate, error) {
+	groupIndex := strings.Index(html, "Anna's Archive")
+	if groupIndex < 0 {
+		return nil, nil
+	}
+
+	monitorKeyIndex := strings.Index(html[groupIndex:], "'monitorList':[")
+	if monitorKeyIndex < 0 {
+		monitorKeyIndex = strings.Index(html[groupIndex:], `"monitorList":[`)
+	}
+	if monitorKeyIndex < 0 {
+		return nil, errors.New("Anna group found but monitor list missing")
+	}
+
+	monitorKeyIndex += groupIndex
+	listStart := strings.Index(html[monitorKeyIndex:], "[")
+	if listStart < 0 {
+		return nil, errors.New("monitor list start missing")
+	}
+
+	listStart += monitorKeyIndex
+	listEnd := findMatchingBracket(html, listStart)
+	if listEnd < 0 {
+		return nil, errors.New("monitor list end missing")
+	}
+
+	return parseCandidatesFromSection(html[listStart : listEnd+1]), nil
+}
+
+func parseCandidatesByURLFallback(html string) []Candidate {
+	matches := fallbackURLRegex.FindAllString(html, -1)
+	seen := make(map[string]struct{})
+	candidates := make([]Candidate, 0, len(matches))
+
+	for _, match := range matches {
+		baseURL := NormalizeBaseURL(match)
+		if _, exists := seen[baseURL]; exists {
+			continue
+		}
+		seen[baseURL] = struct{}{}
+		candidates = append(candidates, Candidate{
+			BaseURL:   baseURL,
+			SourceURL: "https://" + baseURL + "/",
+		})
+	}
+
+	return candidates
+}
+
+func parseCandidatesFromSection(section string) []Candidate {
+	matches := candidateObjectRegex.FindAllStringSubmatch(section, -1)
+	candidates := make([]Candidate, 0, len(matches))
+	seen := make(map[string]struct{})
+
+	for _, match := range matches {
+		if len(match) < 3 {
+			continue
+		}
+
+		baseURL := NormalizeBaseURL(match[2])
+		if !strings.HasPrefix(baseURL, "annas-archive.") {
+			continue
+		}
+
+		if _, exists := seen[baseURL]; exists {
+			continue
+		}
+
+		seen[baseURL] = struct{}{}
+		candidates = append(candidates, Candidate{
+			MonitorID: mustAtoi(match[1]),
+			BaseURL:   baseURL,
+			SourceURL: match[2],
+		})
+	}
+
+	return candidates
+}
+
+func applyHeartbeats(candidates []Candidate, heartbeatList map[string][]Heartbeat) []Candidate {
+	enriched := make([]Candidate, 0, len(candidates))
+
+	for _, candidate := range candidates {
+		if candidate.MonitorID > 0 {
+			candidate.Heartbeats = heartbeatList[fmt.Sprintf("%d", candidate.MonitorID)]
+		}
+		enriched = append(enriched, candidate)
+	}
+
+	return enriched
+}
+
+func rankCandidates(candidates []Candidate) []Candidate {
+	filtered := make([]Candidate, 0, len(candidates))
+	for _, candidate := range candidates {
+		score := candidate.Score()
+		if score.LastStatus == 1 || score.SampleCount == 0 {
+			filtered = append(filtered, candidate)
+		}
+	}
+
+	sort.SliceStable(filtered, func(i, j int) bool {
+		left := filtered[i].Score()
+		right := filtered[j].Score()
+
+		if left.SampleCount == 0 || right.SampleCount == 0 {
+			if left.SampleCount != right.SampleCount {
+				return left.SampleCount > right.SampleCount
+			}
+			return filtered[i].BaseURL < filtered[j].BaseURL
+		}
+
+		leftRate := successRate(left)
+		rightRate := successRate(right)
+		if leftRate != rightRate {
+			return leftRate > rightRate
+		}
+
+		if left.AveragePing != right.AveragePing {
+			return left.AveragePing < right.AveragePing
+		}
+
+		return filtered[i].BaseURL < filtered[j].BaseURL
+	})
+
+	return filtered
+}
+
+func successRate(score CandidateScore) float64 {
+	if score.SampleCount == 0 {
+		return 0
+	}
+
+	return float64(score.SuccessCount) / float64(score.SampleCount)
+}
+
+func extractStatusPageSlug(html string) string {
+	match := slugRegex.FindStringSubmatch(strings.ReplaceAll(html, `\'`, `'`))
+	if len(match) == 2 {
+		return match[1]
+	}
+
+	return defaultStatusPageSlug
+}
+
+func buildHeartbeatURL(statusPageURL, slug string) (string, error) {
+	parsed, err := url.Parse(statusPageURL)
+	if err != nil {
+		return "", err
+	}
+
+	heartbeatPath := fmt.Sprintf("/api/status-page/heartbeat/%s", slug)
+	parsed.Path = heartbeatPath
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+
+	return parsed.String(), nil
+}
+
+func findMatchingBracket(input string, start int) int {
+	depth := 0
+	for idx := start; idx < len(input); idx++ {
+		switch input[idx] {
+		case '[':
+			depth++
+		case ']':
+			depth--
+			if depth == 0 {
+				return idx
+			}
+		}
+	}
+
+	return -1
+}
+
+func mustAtoi(raw string) int {
+	value := 0
+	for _, ch := range raw {
+		value = value*10 + int(ch-'0')
+	}
+	return value
+}

--- a/internal/modes/mcpserver.go
+++ b/internal/modes/mcpserver.go
@@ -234,6 +234,10 @@ func StartMCPServer() {
 	l := logger.GetLogger()
 	defer l.Sync()
 
+	if _, err := env.GetEnv(); err != nil {
+		l.Fatal("Failed to resolve Anna environment at startup", zap.Error(err))
+	}
+
 	serverVersion := version.GetVersion()
 	l.Info("Starting MCP server",
 		zap.String("name", "annas-mcp"),

--- a/internal/modes/mcpserver.go
+++ b/internal/modes/mcpserver.go
@@ -270,10 +270,13 @@ func StartMCPServer(defaultTimeout time.Duration) {
 	l := logger.GetLogger()
 	defer l.Sync()
 
+	annasBaseURL := env.GetAnnasBaseURL()
+
 	serverVersion := version.GetVersion()
 	l.Info("Starting MCP server",
 		zap.String("name", "annas-mcp"),
 		zap.String("version", serverVersion),
+		zap.String("annasBaseURL", annasBaseURL),
 	)
 
 	server := mcp.NewServer("annas-mcp", serverVersion, nil)


### PR DESCRIPTION
## Summary
This PR adds automatic Anna mirror discovery at process startup by reading the public open-slum status page, dynamically extracting Anna mirror candidates, ranking them by recent health, and confirming local reachability before selecting one.

## What changed
- add a new `internal/mirror` resolver that discovers Anna mirrors from open-slum without hardcoding monitor IDs or a fixed domain list
- change environment resolution so automatic discovery is the default behavior
- repurpose `ANNAS_BASE_URL` as a fallback mirror when automatic discovery fails
- add `ANNAS_FIXED_BASE_URL` to explicitly pin one mirror and bypass automatic discovery
- resolve the mirror once per process and reuse it across CLI and MCP operations
- initialize mirror resolution when the MCP server starts so startup failures surface early
- document the new mirror selection behavior and environment variable semantics in the README

## Testing
- `go test ./...`
- local smoke test with automatic selection enabled confirmed search traffic reached a discovered working mirror
- local smoke test with `ANNAS_FIXED_BASE_URL` confirmed explicit pinning overrides automatic discovery

## Notes
This PR intentionally changes the meaning of `ANNAS_BASE_URL`. It is now a fallback value instead of a hard pin. Users who need strict pinning should switch to `ANNAS_FIXED_BASE_URL`.