### PR TITLE
fix: Replaces 30s whole-request timeout with stall-based deadlines

### DIFF
--- a/internal/anna/anna.go
+++ b/internal/anna/anna.go
@@ -1,12 +1,13 @@
 package anna
 
 import (
+	"context"
 	"fmt"
 	"net/url"
+	"time"
 
 	"strings"
 	"sync"
-	"time"
 
 	"encoding/json"
 	"errors"
@@ -27,7 +28,6 @@ const (
 	AnnasSearchEndpointFormat   = "https://%s/search?q=%s&content=%s"
 	AnnasSciDBEndpointFormat    = "https://%s/scidb/%s"
 	AnnasDownloadEndpointFormat = "https://%s/dyn/api/fast_download.json?md5=%s&key=%s"
-	HTTPTimeout                 = 30 * time.Second
 	BrowserUserAgent            = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
 )
 
@@ -351,36 +351,31 @@ func (b *Book) Download(secretKey, folderPath string) error {
 		return fmt.Errorf("failed to get environment: %w", err)
 	}
 
-	// Create HTTP client with timeout
-	client := &http.Client{
-		Timeout: HTTPTimeout,
-	}
-
-	// First API call: get download URL
+	// First API call: get the signed download URL. Small JSON
+	// response; a whole-request timeout is appropriate here.
 	apiURL := fmt.Sprintf(AnnasDownloadEndpointFormat, env.AnnasBaseURL, b.Hash, secretKey)
-
 	l.Info("Fetching download URL", zap.String("hash", b.Hash))
 
-	resp, err := client.Get(apiURL)
+	apiClient := &http.Client{Timeout: 30 * time.Second}
+	resp, err := apiClient.Get(apiURL)
 	if err != nil {
 		return fmt.Errorf("failed to fetch download URL: %w", err)
 	}
 	defer resp.Body.Close()
 
-	// Validate HTTP status code
 	if resp.StatusCode != http.StatusOK {
 		body, readErr := io.ReadAll(io.LimitReader(resp.Body, 512))
 		if readErr != nil {
 			return fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, resp.Status)
 		}
-		return fmt.Errorf("API request failed with status %d: %s (body: %s)", resp.StatusCode, resp.Status, string(body))
+		return fmt.Errorf("API request failed with status %d: %s (body: %s)",
+			resp.StatusCode, resp.Status, string(body))
 	}
 
 	var apiResp fastDownloadResponse
 	if err := json.NewDecoder(resp.Body).Decode(&apiResp); err != nil {
 		return fmt.Errorf("failed to decode API response: %w", err)
 	}
-
 	if apiResp.DownloadURL == "" {
 		if apiResp.Error != "" {
 			return fmt.Errorf("API error: %s", apiResp.Error)
@@ -388,48 +383,45 @@ func (b *Book) Download(secretKey, folderPath string) error {
 		return errors.New("API returned empty download URL")
 	}
 
-	// Second API call: download the file
+	// Second call: stream the file body with stall-based deadlines.
+	// There is no upper bound on transfer duration — only on periods
+	// of zero progress — so large books over slow links succeed as
+	// long as bytes keep flowing.
 	l.Info("Downloading file", zap.String("url", apiResp.DownloadURL))
-
-	downloadResp, err := client.Get(apiResp.DownloadURL)
+	ctx, downloadResp, body, cleanup, err := stallingGet(
+		context.Background(), apiResp.DownloadURL, BrowserUserAgent,
+		30*time.Second, 60*time.Second,
+	)
 	if err != nil {
 		return fmt.Errorf("failed to download file: %w", err)
 	}
+	defer cleanup()
 	defer downloadResp.Body.Close()
 
-	// Validate download status code
 	if downloadResp.StatusCode != http.StatusOK {
 		return fmt.Errorf("download failed with status %d: %s", downloadResp.StatusCode, downloadResp.Status)
 	}
 
-	// Sanitize filename to prevent path traversal and invalid characters
 	safeTitle := sanitizeFilename(b.Title)
 	if safeTitle == "" {
 		safeTitle = "untitled"
 	}
-
 	format := strings.ToLower(b.Format)
 	if format == "" {
 		format = "bin"
 	}
-
-	filename := safeTitle + "." + format
-	filePath := filepath.Join(folderPath, filename)
+	filePath := filepath.Join(folderPath, safeTitle+"."+format)
 
 	l.Info("Creating file", zap.String("path", filePath))
-
-	// Create the file
 	out, err := os.Create(filePath)
 	if err != nil {
 		return fmt.Errorf("failed to create file: %w", err)
 	}
 
-	// Setup cleanup on error
 	success := false
 	defer func() {
 		out.Close()
 		if !success {
-			// Delete partial file on failure
 			if removeErr := os.Remove(filePath); removeErr != nil {
 				l.Warn("Failed to remove partial file",
 					zap.String("path", filePath),
@@ -439,13 +431,14 @@ func (b *Book) Download(secretKey, folderPath string) error {
 		}
 	}()
 
-	// Copy the downloaded content
-	written, err := io.Copy(out, downloadResp.Body)
+	written, err := io.Copy(out, body)
 	if err != nil {
+		if errors.Is(context.Cause(ctx), ErrStalled) {
+			return fmt.Errorf("download stalled after %d bytes: %w", written, ErrStalled)
+		}
 		return fmt.Errorf("failed to write file (wrote %d bytes): %w", written, err)
 	}
 
-	// Sync to disk to ensure data is written
 	if err := out.Sync(); err != nil {
 		return fmt.Errorf("failed to sync file to disk: %w", err)
 	}
@@ -455,7 +448,6 @@ func (b *Book) Download(secretKey, folderPath string) error {
 		zap.String("path", filePath),
 		zap.Int64("bytes", written),
 	)
-
 	return nil
 }
 
@@ -585,36 +577,28 @@ func (p *Paper) Download(folderPath string) error {
 		return fmt.Errorf("failed to get environment: %w", err)
 	}
 
-	// Construct full download URL
 	downloadURL := p.DownloadURL
 	if !strings.HasPrefix(downloadURL, "http") {
 		downloadURL = fmt.Sprintf("https://%s%s", env.AnnasBaseURL, downloadURL)
 	}
 
-	client := &http.Client{
-		Timeout: 2 * HTTPTimeout,
-	}
-
 	l.Info("Downloading paper via SciDB", zap.String("url", downloadURL))
-
-	req, err := http.NewRequest("GET", downloadURL, nil)
-	if err != nil {
-		return fmt.Errorf("failed to create request: %w", err)
-	}
-	req.Header.Set("User-Agent", BrowserUserAgent)
-
-	resp, err := client.Do(req)
+	ctx, resp, body, cleanup, err := stallingGet(
+		context.Background(), downloadURL, BrowserUserAgent,
+		30*time.Second, 60*time.Second,
+	)
 	if err != nil {
 		return fmt.Errorf("failed to download paper: %w", err)
 	}
+	defer cleanup()
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, readErr := io.ReadAll(io.LimitReader(resp.Body, 512))
+		b, readErr := io.ReadAll(io.LimitReader(resp.Body, 512))
 		if readErr != nil {
 			return fmt.Errorf("download failed with status %d: %s", resp.StatusCode, resp.Status)
 		}
-		return fmt.Errorf("download failed with status %d: %s (body: %s)", resp.StatusCode, resp.Status, string(body))
+		return fmt.Errorf("download failed with status %d: %s (body: %s)", resp.StatusCode, resp.Status, string(b))
 	}
 
 	// Infer file extension from Content-Disposition or Content-Type
@@ -634,7 +618,6 @@ func (p *Paper) Download(folderPath string) error {
 		}
 	}
 
-	// Build filename from title or DOI
 	name := p.Title
 	if name == "" {
 		name = p.DOI
@@ -643,11 +626,9 @@ func (p *Paper) Download(folderPath string) error {
 	if safeName == "" {
 		safeName = "paper"
 	}
-	filename := safeName + ext
-	filePath := filepath.Join(folderPath, filename)
+	filePath := filepath.Join(folderPath, safeName+ext)
 
 	l.Info("Creating file", zap.String("path", filePath))
-
 	out, err := os.Create(filePath)
 	if err != nil {
 		return fmt.Errorf("failed to create file: %w", err)
@@ -666,9 +647,12 @@ func (p *Paper) Download(folderPath string) error {
 		}
 	}()
 
-	written, err := io.Copy(out, resp.Body)
-	if err != nil {
-		return fmt.Errorf("failed to write file (wrote %d bytes): %w", written, err)
+	written, copyErr := io.Copy(out, body)
+	if copyErr != nil {
+		if errors.Is(context.Cause(ctx), ErrStalled) {
+			return fmt.Errorf("paper download stalled after %d bytes: %w", written, ErrStalled)
+		}
+		return fmt.Errorf("failed to write file (wrote %d bytes): %w", written, copyErr)
 	}
 
 	if err := out.Sync(); err != nil {
@@ -680,7 +664,6 @@ func (p *Paper) Download(folderPath string) error {
 		zap.String("path", filePath),
 		zap.Int64("bytes", written),
 	)
-
 	return nil
 }
 

--- a/internal/anna/download.go
+++ b/internal/anna/download.go
@@ -1,0 +1,74 @@
+package anna
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"time"
+)
+
+// ErrStalled is the cancellation cause set when a download makes no
+// progress for longer than the stall deadline. After io.Copy returns
+// an error, callers check errors.Is(context.Cause(ctx), ErrStalled)
+// on the ctx returned by stallingGet to distinguish a stall from
+// other cancellations.
+var ErrStalled = errors.New("download stalled: no bytes received within stall timeout")
+
+// stallingGet issues a GET with TTFB-only header deadline and a
+// stall-based body deadline that resets on every successful read.
+// Unlike http.Client.Timeout, which bounds the entire exchange
+// including body reads, there is no upper bound on transfer
+// duration — only on inactivity.
+//
+// The returned ctx is derived from parent and carries the stall
+// watchdog's cancellation. The returned body wraps resp.Body so that
+// every successful Read resets the stall timer. The caller must both
+// Close resp.Body and invoke cleanup() to release the watchdog.
+func stallingGet(
+	parent context.Context,
+	url, userAgent string,
+	headerTimeout, stallTimeout time.Duration,
+) (context.Context, *http.Response, io.Reader, func(), error) {
+	ctx, cancelCause := context.WithCancelCause(parent)
+
+	client := &http.Client{
+		Transport: &http.Transport{ResponseHeaderTimeout: headerTimeout},
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		cancelCause(nil)
+		return ctx, nil, nil, nil, err
+	}
+	if userAgent != "" {
+		req.Header.Set("User-Agent", userAgent)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		cancelCause(nil)
+		return ctx, nil, nil, nil, err
+	}
+
+	timer := time.AfterFunc(stallTimeout, func() { cancelCause(ErrStalled) })
+	body := &stallReader{r: resp.Body, bump: func() { timer.Reset(stallTimeout) }}
+	cleanup := func() {
+		timer.Stop()
+		cancelCause(nil)
+	}
+	return ctx, resp, body, cleanup, nil
+}
+
+// stallReader invokes bump after every successful Read.
+type stallReader struct {
+	r    io.Reader
+	bump func()
+}
+
+func (s *stallReader) Read(p []byte) (int, error) {
+	n, err := s.r.Read(p)
+	if n > 0 {
+		s.bump()
+	}
+	return n, err
+}

--- a/internal/anna/download_test.go
+++ b/internal/anna/download_test.go
@@ -1,0 +1,215 @@
+package anna
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// slowSteadyHandler writes chunkSize bytes every tick, for chunkCount
+// chunks, flushing after each write. Simulates a legitimate slow
+// server: total transfer exceeds any reasonable TTFB timeout, but the
+// inter-chunk gap is well under any sane stall timeout.
+func slowSteadyHandler(chunkSize, chunkCount int, tick time.Duration) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			http.Error(w, "flusher unavailable", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", chunkSize*chunkCount))
+		w.WriteHeader(http.StatusOK)
+		chunk := bytes.Repeat([]byte{'x'}, chunkSize)
+		for i := 0; i < chunkCount; i++ {
+			if _, err := w.Write(chunk); err != nil {
+				return
+			}
+			flusher.Flush()
+			select {
+			case <-time.After(tick):
+			case <-r.Context().Done():
+				return
+			}
+		}
+	}
+}
+
+// stallAfterHeadersHandler sends 200 OK + headers, flushes, then
+// blocks until the client disconnects.
+func stallAfterHeadersHandler(w http.ResponseWriter, r *http.Request) {
+	flusher, _ := w.(http.Flusher)
+	w.WriteHeader(http.StatusOK)
+	if flusher != nil {
+		flusher.Flush()
+	}
+	<-r.Context().Done()
+}
+
+// silentHandler accepts the connection without ever writing a response.
+func silentHandler(_ http.ResponseWriter, r *http.Request) {
+	<-r.Context().Done()
+}
+
+func TestStallingGet_SlowSteadyStreamSucceeds(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(slowSteadyHandler(1024, 30, 100*time.Millisecond))
+	defer srv.Close()
+
+	ctx, resp, body, cleanup, err := stallingGet(
+		context.Background(), srv.URL, "", 1*time.Second, 500*time.Millisecond,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer cleanup()
+	defer resp.Body.Close()
+
+	var buf bytes.Buffer
+	n, err := io.Copy(&buf, body)
+	if err != nil {
+		t.Fatalf("unexpected copy error: %v (cause: %v)", err, context.Cause(ctx))
+	}
+	if n != 30*1024 {
+		t.Fatalf("short write: got %d, want %d", n, 30*1024)
+	}
+}
+
+func TestStallingGet_StallFires(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(stallAfterHeadersHandler))
+	defer srv.Close()
+
+	start := time.Now()
+	ctx, resp, body, cleanup, err := stallingGet(
+		context.Background(), srv.URL, "", 2*time.Second, 200*time.Millisecond,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer cleanup()
+	defer resp.Body.Close()
+
+	_, copyErr := io.Copy(io.Discard, body)
+	elapsed := time.Since(start)
+
+	if copyErr == nil {
+		t.Fatalf("expected copy error on stall, got nil")
+	}
+	if cause := context.Cause(ctx); !errors.Is(cause, ErrStalled) {
+		t.Fatalf("expected context.Cause(ctx) == ErrStalled, got: %v", cause)
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("stall took too long to fire: %v", elapsed)
+	}
+}
+
+func TestStallingGet_HeaderTimeoutFires(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(silentHandler))
+	defer srv.Close()
+
+	start := time.Now()
+	_, _, _, _, err := stallingGet(
+		context.Background(), srv.URL, "", 200*time.Millisecond, 10*time.Second,
+	)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatalf("expected header timeout error, got nil")
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("header timeout took too long to fire: %v", elapsed)
+	}
+}
+
+func TestStallingGet_ExposesHeadersBeforeRead(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Disposition", `attachment; filename="example.pdf"`)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("%PDF-1.4 fake"))
+	}))
+	defer srv.Close()
+
+	_, resp, body, cleanup, err := stallingGet(
+		context.Background(), srv.URL, "", 2*time.Second, 2*time.Second,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer cleanup()
+	defer resp.Body.Close()
+
+	if got := resp.Header.Get("Content-Disposition"); got == "" {
+		t.Fatalf("expected Content-Disposition header, got empty")
+	}
+	b, err := io.ReadAll(body)
+	if err != nil {
+		t.Fatalf("read failed: %v", err)
+	}
+	if !bytes.HasPrefix(b, []byte("%PDF")) {
+		t.Fatalf("unexpected body: %q", b)
+	}
+}
+
+func TestStallingGet_ExternalCancellation(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(slowSteadyHandler(1024, 30, 100*time.Millisecond))
+	defer srv.Close()
+
+	parent, cancelParent := context.WithCancel(context.Background())
+	time.AfterFunc(150*time.Millisecond, cancelParent)
+
+	ctx, resp, body, cleanup, err := stallingGet(
+		parent, srv.URL, "", 2*time.Second, 2*time.Second,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer cleanup()
+	defer resp.Body.Close()
+
+	_, copyErr := io.Copy(io.Discard, body)
+	if copyErr == nil {
+		t.Fatalf("expected cancellation error")
+	}
+	if cause := context.Cause(ctx); errors.Is(cause, ErrStalled) {
+		t.Fatalf("external cancellation should not surface as ErrStalled, got cause: %v", cause)
+	}
+}
+
+// Regression test for the bug the PR fixes: a legitimate slow stream
+// that would be killed by a whole-request http.Client.Timeout must
+// succeed when driven by stallingGet, since the watchdog resets on
+// every successful read.
+func TestStallingGet_ProgressResetsWatchdog(t *testing.T) {
+	t.Parallel()
+	// 3 seconds of total transfer, 100ms gaps, 250ms stall timeout.
+	// A whole-request timeout of 250ms would abort immediately.
+	srv := httptest.NewServer(slowSteadyHandler(512, 30, 100*time.Millisecond))
+	defer srv.Close()
+
+	_, resp, body, cleanup, err := stallingGet(
+		context.Background(), srv.URL, "", 1*time.Second, 250*time.Millisecond,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer cleanup()
+	defer resp.Body.Close()
+
+	var buf bytes.Buffer
+	n, err := io.Copy(&buf, body)
+	if err != nil {
+		t.Fatalf("stall watchdog fired on steady stream: %v", err)
+	}
+	if n != 30*512 {
+		t.Fatalf("short write: got %d, want %d", n, 30*512)
+	}
+}


### PR DESCRIPTION
## Bug

`http.Client.Timeout` on `Book.Download` / `Paper.Download` covers the entire body stream, so any file taking more than 30s to download fails mid-copy:

```
failed to write file (wrote 32534816 bytes): context deadline exceeded (Client.Timeout or context cancellation while reading body)
```

Every book larger than a few tens of megabytes breaks on typical links.

## Fix

Replace the whole-request timeout with a stall-based shape. Add one free helper in `internal/anna/download.go`:

```go
stallingGet(ctx, url, ua, headerTimeout, stallTimeout) (
    ctx, resp, body, cleanup, err)
```

- `Transport.ResponseHeaderTimeout` bounds time-to-first-byte.
- A `time.AfterFunc` stall watchdog resets on every successful `Read` from the response body. On fire, it cancels the request context with `ErrStalled` as the cause.
- After `io.Copy`, callers distinguish a stall from other cancellations via `errors.Is(context.Cause(ctx), ErrStalled)`.

No upper bound on transfer duration — only on inactivity. `Book.Download`'s small `fast_download.json` JSON call keeps a conventional 30s whole-request `Client.Timeout` (response is <1KB).

## Tests

Seven Go tests in `internal/anna/download_test.go` against `httptest.Server`: slow-steady stream succeeds past any whole-request deadline (3s transfer under a 250ms stall timeout), stall fires, TTFB fires, headers accessible before first read, external cancellation not misclassified as stall, progress-resets-watchdog regression.